### PR TITLE
Updated readme to add note about partial application

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ auto-curry
 
 Supercharge your functions by giving them the ability to auto-curry.
 
+> Note:
+> This library actually uses partial application internally and not currying. So, yes, the name is a misnomer.
+> It is the result of my incorrect understanding of the concepts when I wrote the library.
+> It is still perfectly usable and is used in production.
+
 #Installation
 
 ```javascript


### PR DESCRIPTION
Technically, this library uses partial application to mimic currying behaviour.
So yes, the name is a misnomer and a result of me not being clear about the concepts when I wrote the library.
It is still perfectly usable.
I have added the note only for the purists and people who really want a pure currying solution.
